### PR TITLE
ENH: greatly speed up execution

### DIFF
--- a/cobyqa/framework.py
+++ b/cobyqa/framework.py
@@ -16,6 +16,10 @@ from .subsolvers.optim import qr_tangential_byrd_omojokun
 from .utils import get_arrays_tol
 
 
+TINY = np.finfo(float).tiny
+EPS = np.finfo(float).eps
+
+
 class TrustRegion:
     """
     Trust-region framework.
@@ -746,7 +750,7 @@ class TrustRegion:
             norm_g_lag_proj = np.linalg.norm(g_lag_proj)
             if (
                 0 < n_act < self._pb.n
-                and norm_g_lag_proj > np.finfo(float).tiny * self.radius
+                and norm_g_lag_proj > TINY * self.radius
             ):
                 step_alt = (self.radius / norm_g_lag_proj) * g_lag_proj
                 if lag.curv(step_alt, self.models.interpolation) < 0.0:
@@ -885,7 +889,7 @@ class TrustRegion:
         )
         if (
             abs(merit_model_old - merit_model_new)
-            > np.finfo(float).tiny * abs(merit_old - merit_new)
+            > TINY * abs(merit_old - merit_new)
         ):
             return (
                 (merit_old - merit_new)
@@ -922,7 +926,7 @@ class TrustRegion:
             self._lm_nonlinear_ub,
             self._lm_nonlinear_eq,
         ]))
-        if abs(viol_diff) > np.finfo(float).tiny * abs(sqp_val):
+        if abs(viol_diff) > TINY * abs(sqp_val):
             threshold = max(threshold, sqp_val / viol_diff)
         best_index_save = self.best_index
         if (
@@ -962,7 +966,7 @@ class TrustRegion:
         )
         tol = (
             10.0
-            * np.finfo(float).eps
+            * EPS
             * max(self.models.n, self.models.npt)
             * max(abs(m_best), 1.0)
         )
@@ -1224,7 +1228,7 @@ class TrustRegion:
             f_max = np.nanmax(self.models.fun_val)
             c_min_neg = np.minimum(0.0, c_min[indices])
             c_diff = np.min(c_max[indices] - c_min_neg)
-            if c_diff > np.finfo(float).tiny * (f_max - f_min):
+            if c_diff > TINY * (f_max - f_min):
                 penalty = (f_max - f_min) / c_diff
             else:
                 penalty = np.inf

--- a/cobyqa/framework.py
+++ b/cobyqa/framework.py
@@ -470,19 +470,9 @@ class TrustRegion:
             fun_val, cub_val, ceq_val = self._pb(x)
         m_val = fun_val
         if self._penalty > 0.0:
-            c_val = np.block([
-                self._pb.bounds.xl - x,
-                x - self._pb.bounds.xu,
-                self._pb.linear.a_ub @ x - self._pb.linear.b_ub,
-                cub_val,
-            ])
-            c_val = np.maximum(c_val, 0.0)
-            c_val = np.block([
-                c_val,
-                np.abs(self._pb.linear.a_eq @ x - self._pb.linear.b_eq),
-                np.abs(ceq_val),
-            ])
-            m_val += self._penalty * np.linalg.norm(c_val)
+            c_val = self._pb.violation(x, cub_val=cub_val, ceq_val=ceq_val)
+            if np.count_nonzero(c_val):
+                m_val += self._penalty * np.linalg.norm(c_val)
         return m_val
 
     def get_constraint_linearizations(self, x):

--- a/cobyqa/main.py
+++ b/cobyqa/main.py
@@ -76,7 +76,7 @@ def minimize(
            to :math:`\infty` if there is no upper bound.
 
         The COBYQA method always respect the bound constraints.
-    constraints : {Constraint, dict, list}, optional
+    constraints : {Constraint, list}, optional
         General constraints of the problem. It can be one of the cases below.
 
         #. An instance of `scipy.optimize.LinearConstraint`. The argument
@@ -84,15 +84,6 @@ def minimize(
         #. An instance of `scipy.optimize.NonlinearConstraint`. The arguments
            ``jac``, ``hess``, ``keep_feasible``, ``finite_diff_rel_step``, and
            ``finite_diff_jac_sparsity`` are disregarded.
-        #. A dictionary with fields:
-
-            type : {'eq', 'ineq'}
-                Whether the constraint is an equality ``fun(x, *args) == 0`` or
-                an inequality ``fun(x, *args) >= 0``.
-            fun : callable
-                Constraint function.
-            args : tuple, optional
-                Extra arguments passed to the constraint function.
 
         #. A list, each of whose elements are described in the cases above.
 

--- a/cobyqa/main.py
+++ b/cobyqa/main.py
@@ -577,7 +577,8 @@ def minimize(
         if (
             np.linalg.norm(
                 framework.x_best - framework.models.interpolation.x_base
-            ) >= constants[Constants.LARGE_SHIFT_FACTOR] * framework.radius
+            )
+            >= constants[Constants.LARGE_SHIFT_FACTOR] * framework.radius
         ):
             framework.shift_x_base(options)
 
@@ -658,10 +659,7 @@ def minimize(
                     framework.ceq_best,
                 )
                 merit_new = framework.merit(
-                    framework.x_best + step,
-                    fun_val,
-                    cub_val,
-                    ceq_val
+                    framework.x_best + step, fun_val, cub_val, ceq_val
                 )
                 if (
                     pb.type == "nonlinearly constrained"
@@ -671,8 +669,7 @@ def minimize(
                     * framework.radius
                 ):
                     soc_step = framework.get_second_order_correction_step(
-                        step,
-                        options
+                        step, options
                     )
                     if np.linalg.norm(soc_step) > 0.0:
                         step += soc_step
@@ -721,11 +718,7 @@ def minimize(
                 # Update the interpolation set.
                 try:
                     ill_conditioned = framework.models.update_interpolation(
-                        k_new,
-                        framework.x_best + step,
-                        fun_val,
-                        cub_val,
-                        ceq_val
+                        k_new, framework.x_best + step, fun_val, cub_val, ceq_val
                     )
                 except np.linalg.LinAlgError:
                     status = ExitStatus.LINALG_ERROR
@@ -802,9 +795,7 @@ def minimize(
 
             if verbose:
                 maxcv_val = pb.maxcv(
-                    framework.x_best,
-                    framework.cub_best,
-                    framework.ceq_best
+                    framework.x_best, framework.cub_best, framework.ceq_best
                 )
                 _print_step(
                     f"New trust-region radius: {framework.resolution}",
@@ -913,29 +904,35 @@ def _get_constraints(constraints):
                 constraint.ub,
                 "The upper bound of the linear constraints must be a vector.",
             )
-            linear_constraints.append(LinearConstraint(
-                constraint.A,
-                *np.broadcast_arrays(lb, ub),
-            ))
+            linear_constraints.append(
+                LinearConstraint(
+                    constraint.A,
+                    *np.broadcast_arrays(lb, ub),
+                )
+            )
         elif isinstance(constraint, NonlinearConstraint):
             lb = exact_1d_array(
                 constraint.lb,
-                "The lower bound of the " "nonlinear constraints must be a "
+                "The lower bound of the "
+                "nonlinear constraints must be a "
                 "vector.",
             )
             ub = exact_1d_array(
                 constraint.ub,
-                "The upper bound of the " "nonlinear constraints must be a "
+                "The upper bound of the "
+                "nonlinear constraints must be a "
                 "vector.",
             )
-            nonlinear_constraints.append(NonlinearConstraint(
-                constraint.fun,
-                *np.broadcast_arrays(lb, ub),
-            ))
+            nonlinear_constraints.append(
+                NonlinearConstraint(
+                    constraint.fun,
+                    *np.broadcast_arrays(lb, ub),
+                )
+            )
         elif isinstance(constraint, dict):
-            if (
-                "type" not in constraint
-                or constraint["type"] not in ("eq", "ineq")
+            if "type" not in constraint or constraint["type"] not in (
+                "eq",
+                "ineq",
             ):
                 raise ValueError('The constraint type must be "eq" or "ineq".')
             if "fun" not in constraint or not callable(constraint["fun"]):
@@ -971,24 +968,26 @@ def _set_default_options(options, n):
                 "than or equal to the final trust-region radius."
             )
     elif Options.RHOBEG in options:
-        options[Options.RHOEND.value] = np.min([
-            DEFAULT_OPTIONS[Options.RHOEND],
-            options[Options.RHOBEG],
-        ])
+        options[Options.RHOEND.value] = np.min(
+            [
+                DEFAULT_OPTIONS[Options.RHOEND],
+                options[Options.RHOBEG],
+            ]
+        )
     elif Options.RHOEND in options:
-        options[Options.RHOBEG.value] = np.max([
-            DEFAULT_OPTIONS[Options.RHOBEG],
-            options[Options.RHOEND],
-        ])
+        options[Options.RHOBEG.value] = np.max(
+            [
+                DEFAULT_OPTIONS[Options.RHOBEG],
+                options[Options.RHOEND],
+            ]
+        )
     else:
         options[Options.RHOBEG.value] = DEFAULT_OPTIONS[Options.RHOBEG]
         options[Options.RHOEND.value] = DEFAULT_OPTIONS[Options.RHOEND]
     options[Options.RHOBEG.value] = float(options[Options.RHOBEG])
     options[Options.RHOEND.value] = float(options[Options.RHOEND])
     if Options.NPT in options and options[Options.NPT] <= 0:
-        raise ValueError(
-            "The number of interpolation points must be positive."
-        )
+        raise ValueError("The number of interpolation points must be positive.")
     if (
         Options.NPT in options
         and options[Options.NPT] > ((n + 1) * (n + 2)) // 2
@@ -1005,10 +1004,12 @@ def _set_default_options(options, n):
         )
     options.setdefault(
         Options.MAX_EVAL.value,
-        np.max([
-            DEFAULT_OPTIONS[Options.MAX_EVAL](n),
-            options[Options.NPT] + 1,
-        ]),
+        np.max(
+            [
+                DEFAULT_OPTIONS[Options.MAX_EVAL](n),
+                options[Options.NPT] + 1,
+            ]
+        ),
     )
     options[Options.MAX_EVAL.value] = int(options[Options.MAX_EVAL])
     if Options.MAX_ITER in options and options[Options.MAX_ITER] <= 0:
@@ -1113,22 +1114,26 @@ def _set_default_constants(**kwargs):
                 "less than increase_radius_factor."
             )
     elif Constants.INCREASE_RADIUS_FACTOR in constants:
-        constants[Constants.DECREASE_RADIUS_THRESHOLD.value] = np.min([
-            DEFAULT_CONSTANTS[Constants.DECREASE_RADIUS_THRESHOLD],
-            0.5 * (1.0 + constants[Constants.INCREASE_RADIUS_FACTOR]),
-        ])
+        constants[Constants.DECREASE_RADIUS_THRESHOLD.value] = np.min(
+            [
+                DEFAULT_CONSTANTS[Constants.DECREASE_RADIUS_THRESHOLD],
+                0.5 * (1.0 + constants[Constants.INCREASE_RADIUS_FACTOR]),
+            ]
+        )
     elif Constants.DECREASE_RADIUS_THRESHOLD in constants:
-        constants[Constants.INCREASE_RADIUS_FACTOR.value] = np.max([
-            DEFAULT_CONSTANTS[Constants.INCREASE_RADIUS_FACTOR],
-            2.0 * constants[Constants.DECREASE_RADIUS_THRESHOLD],
-        ])
+        constants[Constants.INCREASE_RADIUS_FACTOR.value] = np.max(
+            [
+                DEFAULT_CONSTANTS[Constants.INCREASE_RADIUS_FACTOR],
+                2.0 * constants[Constants.DECREASE_RADIUS_THRESHOLD],
+            ]
+        )
     else:
-        constants[Constants.INCREASE_RADIUS_FACTOR.value] = (
-            DEFAULT_CONSTANTS[Constants.INCREASE_RADIUS_FACTOR]
-        )
-        constants[Constants.DECREASE_RADIUS_THRESHOLD.value] = (
-            DEFAULT_CONSTANTS[Constants.DECREASE_RADIUS_THRESHOLD]
-        )
+        constants[Constants.INCREASE_RADIUS_FACTOR.value] = DEFAULT_CONSTANTS[
+            Constants.INCREASE_RADIUS_FACTOR
+        ]
+        constants[Constants.DECREASE_RADIUS_THRESHOLD.value] = DEFAULT_CONSTANTS[
+            Constants.DECREASE_RADIUS_THRESHOLD
+        ]
     constants.setdefault(
         Constants.DECREASE_RESOLUTION_FACTOR.value,
         DEFAULT_CONSTANTS[Constants.DECREASE_RESOLUTION_FACTOR],
@@ -1172,15 +1177,19 @@ def _set_default_constants(**kwargs):
                 "must be at most large_resolution_threshold."
             )
     elif Constants.LARGE_RESOLUTION_THRESHOLD in constants:
-        constants[Constants.MODERATE_RESOLUTION_THRESHOLD.value] = np.min([
-            DEFAULT_CONSTANTS[Constants.MODERATE_RESOLUTION_THRESHOLD],
-            constants[Constants.LARGE_RESOLUTION_THRESHOLD],
-        ])
+        constants[Constants.MODERATE_RESOLUTION_THRESHOLD.value] = np.min(
+            [
+                DEFAULT_CONSTANTS[Constants.MODERATE_RESOLUTION_THRESHOLD],
+                constants[Constants.LARGE_RESOLUTION_THRESHOLD],
+            ]
+        )
     elif Constants.MODERATE_RESOLUTION_THRESHOLD in constants:
-        constants[Constants.LARGE_RESOLUTION_THRESHOLD.value] = np.max([
-            DEFAULT_CONSTANTS[Constants.LARGE_RESOLUTION_THRESHOLD],
-            constants[Constants.MODERATE_RESOLUTION_THRESHOLD],
-        ])
+        constants[Constants.LARGE_RESOLUTION_THRESHOLD.value] = np.max(
+            [
+                DEFAULT_CONSTANTS[Constants.LARGE_RESOLUTION_THRESHOLD],
+                constants[Constants.MODERATE_RESOLUTION_THRESHOLD],
+            ]
+        )
     else:
         constants[Constants.LARGE_RESOLUTION_THRESHOLD.value] = (
             DEFAULT_CONSTANTS[Constants.LARGE_RESOLUTION_THRESHOLD]
@@ -1208,22 +1217,26 @@ def _set_default_constants(**kwargs):
                 "The constant low_ratio must be at most high_ratio."
             )
     elif Constants.LOW_RATIO in constants:
-        constants[Constants.HIGH_RATIO.value] = np.max([
-            DEFAULT_CONSTANTS[Constants.HIGH_RATIO],
-            constants[Constants.LOW_RATIO],
-        ])
+        constants[Constants.HIGH_RATIO.value] = np.max(
+            [
+                DEFAULT_CONSTANTS[Constants.HIGH_RATIO],
+                constants[Constants.LOW_RATIO],
+            ]
+        )
     elif Constants.HIGH_RATIO in constants:
-        constants[Constants.LOW_RATIO.value] = np.min([
-            DEFAULT_CONSTANTS[Constants.LOW_RATIO],
-            constants[Constants.HIGH_RATIO],
-        ])
+        constants[Constants.LOW_RATIO.value] = np.min(
+            [
+                DEFAULT_CONSTANTS[Constants.LOW_RATIO],
+                constants[Constants.HIGH_RATIO],
+            ]
+        )
     else:
-        constants[Constants.LOW_RATIO.value] = (
-            DEFAULT_CONSTANTS[Constants.LOW_RATIO]
-        )
-        constants[Constants.HIGH_RATIO.value] = (
-            DEFAULT_CONSTANTS[Constants.HIGH_RATIO]
-        )
+        constants[Constants.LOW_RATIO.value] = DEFAULT_CONSTANTS[
+            Constants.LOW_RATIO
+        ]
+        constants[Constants.HIGH_RATIO.value] = DEFAULT_CONSTANTS[
+            Constants.HIGH_RATIO
+        ]
     constants.setdefault(
         Constants.VERY_LOW_RATIO.value,
         DEFAULT_CONSTANTS[Constants.VERY_LOW_RATIO],
@@ -1267,22 +1280,26 @@ def _set_default_constants(**kwargs):
                 "penalty_increase_threshold."
             )
     elif Constants.PENALTY_INCREASE_THRESHOLD in constants:
-        constants[Constants.PENALTY_INCREASE_FACTOR.value] = np.max([
-            DEFAULT_CONSTANTS[Constants.PENALTY_INCREASE_FACTOR],
-            constants[Constants.PENALTY_INCREASE_THRESHOLD],
-        ])
+        constants[Constants.PENALTY_INCREASE_FACTOR.value] = np.max(
+            [
+                DEFAULT_CONSTANTS[Constants.PENALTY_INCREASE_FACTOR],
+                constants[Constants.PENALTY_INCREASE_THRESHOLD],
+            ]
+        )
     elif Constants.PENALTY_INCREASE_FACTOR in constants:
-        constants[Constants.PENALTY_INCREASE_THRESHOLD.value] = np.min([
-            DEFAULT_CONSTANTS[Constants.PENALTY_INCREASE_THRESHOLD],
-            constants[Constants.PENALTY_INCREASE_FACTOR],
-        ])
+        constants[Constants.PENALTY_INCREASE_THRESHOLD.value] = np.min(
+            [
+                DEFAULT_CONSTANTS[Constants.PENALTY_INCREASE_THRESHOLD],
+                constants[Constants.PENALTY_INCREASE_FACTOR],
+            ]
+        )
     else:
         constants[Constants.PENALTY_INCREASE_THRESHOLD.value] = (
             DEFAULT_CONSTANTS[Constants.PENALTY_INCREASE_THRESHOLD]
         )
-        constants[Constants.PENALTY_INCREASE_FACTOR.value] = (
-            DEFAULT_CONSTANTS[Constants.PENALTY_INCREASE_FACTOR]
-        )
+        constants[Constants.PENALTY_INCREASE_FACTOR.value] = DEFAULT_CONSTANTS[
+            Constants.PENALTY_INCREASE_FACTOR
+        ]
     constants.setdefault(
         Constants.SHORT_STEP_THRESHOLD.value,
         DEFAULT_CONSTANTS[Constants.SHORT_STEP_THRESHOLD],
@@ -1344,9 +1361,7 @@ def _set_default_constants(**kwargs):
         constants[Constants.LARGE_SHIFT_FACTOR]
     )
     if constants[Constants.LARGE_SHIFT_FACTOR] < 0.0:
-        raise ValueError(
-            "The constant large_shift_factor must be nonnegative."
-        )
+        raise ValueError("The constant large_shift_factor must be nonnegative.")
     constants.setdefault(
         Constants.LARGE_GRADIENT_FACTOR.value,
         DEFAULT_CONSTANTS[Constants.LARGE_GRADIENT_FACTOR],
@@ -1414,20 +1429,13 @@ def _build_result(pb, penalty, success, status, n_iter, options):
         success = success and maxcv <= options[Options.FEASIBILITY_TOL]
     result = OptimizeResult()
     result.message = {
-        ExitStatus.RADIUS_SUCCESS:
-            "The lower bound for the trust-region radius has been reached",
-        ExitStatus.TARGET_SUCCESS:
-            "The target objective function value has been reached",
-        ExitStatus.FIXED_SUCCESS:
-            "All variables are fixed by the bound constraints",
-        ExitStatus.CALLBACK_SUCCESS:
-            "The callback requested to stop the optimization procedure",
-        ExitStatus.FEASIBLE_SUCCESS:
-            "The feasibility problem received has been solved successfully",
-        ExitStatus.MAX_EVAL_WARNING:
-            "The maximum number of function evaluations has been exceeded",
-        ExitStatus.MAX_ITER_WARNING:
-            "The maximum number of iterations has been exceeded",
+        ExitStatus.RADIUS_SUCCESS: "The lower bound for the trust-region radius has been reached",
+        ExitStatus.TARGET_SUCCESS: "The target objective function value has been reached",
+        ExitStatus.FIXED_SUCCESS: "All variables are fixed by the bound constraints",
+        ExitStatus.CALLBACK_SUCCESS: "The callback requested to stop the optimization procedure",
+        ExitStatus.FEASIBLE_SUCCESS: "The feasibility problem received has been solved successfully",
+        ExitStatus.MAX_EVAL_WARNING: "The maximum number of function evaluations has been exceeded",
+        ExitStatus.MAX_ITER_WARNING: "The maximum number of iterations has been exceeded",
         ExitStatus.INFEASIBLE_ERROR: "The bound constraints are infeasible",
         ExitStatus.LINALG_ERROR: "A linear algebra error occurred",
     }.get(status, "Unknown exit status")

--- a/cobyqa/models.py
+++ b/cobyqa/models.py
@@ -7,6 +7,9 @@ from .settings import Options
 from .utils import MaxEvalError, TargetSuccess, FeasibleSuccess
 
 
+EPS = np.finfo(float).eps
+
+
 class Interpolation:
     """
     Interpolation set.
@@ -502,7 +505,7 @@ class Quadratic:
         # difficulties.
         scale = np.max(
             [np.linalg.norm(interpolation.xpt[:, k]) for k in range(npt)],
-            initial=np.finfo(float).eps,
+            initial=EPS,
         )
         xpt_scale = interpolation.xpt / scale
 
@@ -537,7 +540,7 @@ class Quadratic:
                 "The interpolation system is ill-defined."
             )
         eig_values, eig_vectors = eigh(a, check_finite=False)
-        large_eig_values = np.abs(eig_values) > np.finfo(float).eps
+        large_eig_values = np.abs(eig_values) > EPS
         eig_vectors = eig_vectors[:, large_eig_values]
         inv_eig_values = 1.0 / eig_values[large_eig_values]
         ill_conditioned = ~np.all(large_eig_values, 0)
@@ -1455,7 +1458,7 @@ class Models:
                 ),
                 initial=error_ceq,
             )
-        tol = 10.0 * np.sqrt(np.finfo(float).eps) * max(self.n, self.npt)
+        tol = 10.0 * np.sqrt(EPS) * max(self.n, self.npt)
         if error_fun > tol * np.max(np.abs(self.fun_val), initial=1.0):
             warnings.warn(
                 "The interpolation conditions for the objective function are "

--- a/cobyqa/problem.py
+++ b/cobyqa/problem.py
@@ -1,5 +1,6 @@
 from contextlib import suppress
 from inspect import signature
+import copy
 
 import numpy as np
 from scipy.optimize import (
@@ -8,6 +9,8 @@ from scipy.optimize import (
     NonlinearConstraint,
     OptimizeResult,
 )
+from scipy.optimize._constraints import PreparedConstraint
+
 
 from .settings import PRINT_OPTIONS, BARRIER
 from .utils import CallbackSuccess, get_arrays_tol
@@ -127,6 +130,7 @@ class BoundConstraints:
 
         self.is_feasible = np.all(self.xl <= self.xu) and np.all(self.xl < np.inf) and np.all(self.xu > -np.inf)
         self.m = np.count_nonzero(self.xl > -np.inf) + np.count_nonzero(self.xu < np.inf)
+        self.pcs = PreparedConstraint(bounds, np.ones(bounds.lb.size))
 
     @property
     def xl(self):
@@ -167,8 +171,14 @@ class BoundConstraints:
             Maximum constraint violation at `x`.
         """
         x = np.asarray(x, dtype=float)
-        val = np.max(self.xl - x, initial=0.0)
-        return np.max(x - self.xu, initial=val)
+        return self.violation(x)
+
+    def violation(self, x):
+        # shortcut for no bounds
+        if self.is_feasible:
+            return np.array([])
+        else:
+            return self.pcs.violation(x)
 
     def project(self, x):
         """
@@ -249,6 +259,7 @@ class LinearConstraints:
         self._b_ub = self.b_ub[~undef_ub]
         self._a_eq = self.a_eq[~undef_eq, :]
         self._b_eq = self.b_eq[~undef_eq]
+        self.pcs = [PreparedConstraint(c, np.ones(n)) for c in constraints if c.A.size]
 
     @property
     def a_ub(self):
@@ -336,11 +347,12 @@ class LinearConstraints:
         float
             Maximum constraint violation at `x`.
         """
-        x = np.array(x, dtype=float)
-        return np.max([
-            np.max(self.a_ub @ x - self.b_ub, initial=0.0),
-            np.max(np.abs(self.a_eq @ x - self.b_eq), initial=0.0),
-        ])
+        return np.max(self.violation(x), initial=0.0)
+
+    def violation(self, x):
+        if len(self.pcs):
+            return np.concatenate([pc.violation(x) for pc in self.pcs])
+        return np.array([])
 
 
 class NonlinearConstraints:
@@ -364,22 +376,22 @@ class NonlinearConstraints:
         if debug:
             assert isinstance(constraints, list)
             for constraint in constraints:
-                assert (
-                    isinstance(constraint, NonlinearConstraint)
-                    or isinstance(constraint, dict)
-                )
+                assert isinstance(constraint, NonlinearConstraint)
             assert isinstance(verbose, bool)
             assert isinstance(debug, bool)
 
         self._constraints = constraints
+        self.pcs = []
         self._verbose = verbose
-        self._m_ub = None
-        self._m_eq = None
-        self._n_eval = 0
+
+        # map of indexes for equality and inequality constraints
+        self._map_ub = None
+        self._map_eq = None
+        self._m_ub = self._m_eq = 0
 
     def __call__(self, x):
         """
-        Evaluate the constraints.
+        Calculates the residual (slack) for the constraints.
 
         Parameters
         ----------
@@ -389,72 +401,94 @@ class NonlinearConstraints:
         Returns
         -------
         `numpy.ndarray`, shape (m_nonlinear_ub,)
-            Nonlinear inequality constraint function values.
+            Nonlinear inequality constraint slack values.
         `numpy.ndarray`, shape (m_nonlinear_eq,)
-            Nonlinear equality constraint function values.
+            Nonlinear equality constraint slack values.
         """
+        if not len(self._constraints):
+            return np.array([]), np.array([])
+
         x = np.array(x, dtype=float)
-        c_ub = np.empty(0)
-        c_eq = np.empty(0)
-        for constraint in self._constraints:
-            if isinstance(constraint, NonlinearConstraint):
-                fun = constraint.fun
-                val = fun(x)
-            else:
-                fun = constraint["fun"]
-                args = constraint["args"]
-                if not isinstance(args, tuple):
-                    args = (args,)
-                val = fun(x, *args)
-            val = exact_1d_array(
-                val,
-                "The nonlinear constraints must return a vector.",
-            )
+        # first time around the constraints haven't been prepared
+        if not len(self.pcs):
+            self._map_ub = []
+            self._map_eq = []
+
+            m = len(x)
+            for constraint in self._constraints:
+                if not callable(constraint.jac):
+                    # having a callable constraint constraint function
+                    # prevents constraint.fun from being evaluated when
+                    # preparing constraint
+                    c = copy.copy(constraint)
+                    c.jac = lambda x0: x0
+                    c.hess = lambda x0, v: 0.
+                    pc = PreparedConstraint(c, x)
+                else:
+                    pc = PreparedConstraint(constraint, x)
+                self.pcs.append(pc)
+                idx = np.arange(pc.fun.m)
+
+                # figure out equality and inequality maps
+                lb, ub = pc.bounds[0], pc.bounds[1]
+                arr_tol = get_arrays_tol(lb, ub)
+                is_equality = np.abs(ub - lb) <= arr_tol
+                self._map_eq.append(idx[is_equality])
+                self._map_ub.append(idx[~is_equality])
+
+                # these values will be corrected to their proper values later
+                self._m_eq += np.count_nonzero(is_equality)
+                self._m_ub += np.count_nonzero(~is_equality)
+
+        c_ub = []
+        c_eq = []
+        for i, pc in enumerate(self.pcs):
+            val = pc.fun.fun(x)
             if self._verbose:
                 with np.printoptions(**PRINT_OPTIONS):
                     with suppress(AttributeError):
-                        fun_name = fun.__name__
+                        fun_name = pc.fun.__name__
                         print(f"{fun_name}({x}) = {val}")
-            if isinstance(constraint, NonlinearConstraint):
-                val, lb, ub = np.broadcast_arrays(
-                    val,
-                    constraint.lb,
-                    constraint.ub,
-                )
-                lb = np.array(lb, float)
-                ub = np.array(ub, float)
-                lb[np.isnan(lb)] = -np.inf
-                ub[np.isnan(ub)] = np.inf
-                is_equality = np.abs(ub - lb) <= get_arrays_tol(lb, ub)
-                if np.any(is_equality):
-                    c_eq = np.concatenate((
-                        c_eq,
-                        val[is_equality]
-                        - 0.5 * (lb[is_equality] + ub[is_equality]),
-                    ))
-                if not np.all(is_equality):
-                    is_inequality_lb = ~is_equality & (lb > -np.inf)
-                    is_inequality_ub = ~is_equality & (ub < np.inf)
-                    if np.any(is_inequality_lb):
-                        c_ub = np.concatenate((
-                            c_ub,
-                            lb[is_inequality_lb] - val[is_inequality_lb],
-                        ))
-                    if np.any(is_inequality_ub):
-                        c_ub = np.concatenate((
-                            c_ub,
-                            val[is_inequality_ub] - ub[is_inequality_ub],
-                        ))
-            elif constraint["type"] == "ineq":
-                c_ub = np.concatenate((c_ub, -val))
-            else:
-                c_eq = np.concatenate((c_eq, val))
-        if len(self._constraints) > 0:
-            self._n_eval += 1
-        if self._m_ub is None:
-            self._m_ub = c_ub.size
-        if self._m_eq is None:
-            self._m_eq = c_eq.size
+                        
+            # separate violations into c_eq and c_ub
+            eq_idx = self._map_eq[i]
+            ub_idx = self._map_ub[i]
+
+            ub_val = val[ub_idx]
+            if len(ub_idx):
+                xl = pc.bounds[0][ub_idx]
+                xu = pc.bounds[1][ub_idx]
+
+                # calculate slack within lower bound
+                finite_xl = xl > -np.inf
+                _v = xl[finite_xl] - ub_val[finite_xl]
+                c_ub.append(_v)
+
+                # calculate slack within lower bound
+                finite_xu = xu < np.inf
+                _v = ub_val[finite_xu] - xu[finite_xu]
+                c_ub.append(_v)
+
+            # equality constraints taken from midpoint between lb and ub
+            eq_val = val[eq_idx]
+            if len(eq_idx):
+                midpoint = 0.5 * (pc.bounds[1][eq_idx] + pc.bounds[0][eq_idx])
+                eq_val -= midpoint
+            c_eq.append(eq_val)
+
+        if self._m_eq:
+            c_eq = np.concatenate(c_eq)
+        else:
+            c_eq = np.array([])
+
+        if self._m_ub:
+            c_ub = np.concatenate(c_ub)
+        else:
+            c_ub = np.array([])
+
+        self._m_ub = c_ub.size
+        self._m_eq = c_eq.size
+
         return c_ub, c_eq
 
     @property
@@ -511,7 +545,10 @@ class NonlinearConstraints:
         int
             Number of function evaluations.
         """
-        return self._n_eval
+        if len(self.pcs):
+            return self.pcs[0].fun.nfev
+        else:
+            return 0
 
     def maxcv(self, x, cub_val=None, ceq_val=None):
         """
@@ -533,12 +570,10 @@ class NonlinearConstraints:
         float
             Maximum constraint violation at `x`.
         """
-        if cub_val is None or ceq_val is None:
-            cub_val, ceq_val = self(x)
-        return np.max([
-            np.max(cub_val, initial=0.0),
-            np.max(np.abs(ceq_val), initial=0.0),
-        ])
+        return np.max(self.violation(x, cub_val=cub_val, ceq_val=ceq_val), initial=0.0)
+
+    def violation(self, x, cub_val=None, ceq_val=None):
+        return np.concatenate([pc.violation(x) for pc in self.pcs])
 
 
 class Problem:
@@ -885,7 +920,7 @@ class Problem:
         int
             Number of function evaluations.
         """
-        return max(self._obj.n_eval, self._nonlinear.n_eval)
+        return self._obj.n_eval
 
     @property
     def fun_name(self):
@@ -1100,11 +1135,27 @@ class Problem:
         float
             Maximum constraint violation at `x`.
         """
-        return np.max([
-            self.bounds.maxcv(x),
-            self.linear.maxcv(x),
-            self._nonlinear.maxcv(x, cub_val, ceq_val),
-        ])
+        violation = self.violation(x, cub_val=cub_val, ceq_val=ceq_val)
+        if np.count_nonzero(violation):
+            return np.max(violation, initial=0.0)
+        else:
+            return 0.
+
+    def violation(self, x, cub_val=None, ceq_val=None):
+        violation = []
+        if not self.bounds.is_feasible:
+            b = self.bounds.violation(x)
+            violation.append(b)
+
+        if len(self.linear.pcs):
+            lc = self.linear.violation(x)
+            violation.append(lc)
+        if len(self._nonlinear.pcs):
+            nlc = self._nonlinear.violation(x, cub_val, ceq_val)
+            violation.append(nlc)
+
+        if len(violation):
+            return np.concatenate(violation)
 
     def best_eval(self, penalty):
         """

--- a/cobyqa/problem.py
+++ b/cobyqa/problem.py
@@ -125,6 +125,9 @@ class BoundConstraints:
         self.xl[np.isnan(self.xl)] = -np.inf
         self.xu[np.isnan(self.xu)] = np.inf
 
+        self.is_feasible = np.all(self.xl <= self.xu) and np.all(self.xl < np.inf) and np.all(self.xu > -np.inf)
+        self.m = np.count_nonzero(self.xl > -np.inf) + np.count_nonzero(self.xu < np.inf)
+
     @property
     def xl(self):
         """
@@ -148,37 +151,6 @@ class BoundConstraints:
             Upper bound.
         """
         return self._xu
-
-    @property
-    def m(self):
-        """
-        Number of bound constraints.
-
-        Returns
-        -------
-        int
-            Number of bound constraints.
-        """
-        return (
-            np.count_nonzero(self.xl > -np.inf)
-            + np.count_nonzero(self.xu < np.inf)
-        )
-
-    @property
-    def is_feasible(self):
-        """
-        Whether the bound constraints are feasible.
-
-        Returns
-        -------
-        bool
-            Whether the bound constraints are feasible.
-        """
-        return (
-            np.all(self.xl <= self.xu)
-            and np.all(self.xl < np.inf)
-            and np.all(self.xu > -np.inf)
-        )
 
     def maxcv(self, x):
         """

--- a/cobyqa/subsolvers/geometry.py
+++ b/cobyqa/subsolvers/geometry.py
@@ -194,27 +194,35 @@ def spider_geometry(const, grad, curv, xpt, xl, xu, delta, debug):
     # xl.shape = (N,)
     # xpt.shape = (N, M)
     # i_xl_pos.shape = (M, N)
-    i_xl_pos = ((xl > -np.inf) & (xpt.T > -TINY * xl))
-    i_xl_neg = ((xl > -np.inf) & (xpt.T < TINY * xl))
-    i_xu_pos = ((xu < np.inf) & (xpt.T > TINY * xu))
-    i_xu_neg = ((xu < np.inf) & (xpt.T < -TINY * xu))
+    i_xl_pos = (xl > -np.inf) & (xpt.T > -TINY * xl)
+    i_xl_neg = (xl > -np.inf) & (xpt.T < TINY * xl)
+    i_xu_pos = (xu < np.inf) & (xpt.T > TINY * xu)
+    i_xu_neg = (xu < np.inf) & (xpt.T < -TINY * xu)
 
     # (M, N)
-    alpha_xl_pos = np.atleast_2d(np.broadcast_to(xl, i_xl_pos.shape)[i_xl_pos] / xpt.T[i_xl_pos])
+    alpha_xl_pos = np.atleast_2d(
+        np.broadcast_to(xl, i_xl_pos.shape)[i_xl_pos] / xpt.T[i_xl_pos]
+    )
     # (M,)
     alpha_xl_pos = np.max(alpha_xl_pos, axis=1, initial=-np.inf)
     # make sure it's (M,)
     alpha_xl_pos = np.broadcast_to(np.atleast_1d(alpha_xl_pos), xpt.shape[1])
 
-    alpha_xl_neg = np.atleast_2d(np.broadcast_to(xl, i_xl_neg.shape)[i_xl_neg] / xpt.T[i_xl_neg])
+    alpha_xl_neg = np.atleast_2d(
+        np.broadcast_to(xl, i_xl_neg.shape)[i_xl_neg] / xpt.T[i_xl_neg]
+    )
     alpha_xl_neg = np.max(alpha_xl_neg, axis=1, initial=np.inf)
     alpha_xl_neg = np.broadcast_to(np.atleast_1d(alpha_xl_neg), xpt.shape[1])
 
-    alpha_xu_neg = np.atleast_2d(np.broadcast_to(xu, i_xu_neg.shape)[i_xu_neg] / xpt.T[i_xu_neg])
+    alpha_xu_neg = np.atleast_2d(
+        np.broadcast_to(xu, i_xu_neg.shape)[i_xu_neg] / xpt.T[i_xu_neg]
+    )
     alpha_xu_neg = np.max(alpha_xu_neg, axis=1, initial=-np.inf)
     alpha_xu_neg = np.broadcast_to(np.atleast_1d(alpha_xu_neg), xpt.shape[1])
 
-    alpha_xu_pos = np.atleast_2d(np.broadcast_to(xu, i_xu_pos.shape)[i_xu_pos] / xpt.T[i_xu_pos])
+    alpha_xu_pos = np.atleast_2d(
+        np.broadcast_to(xu, i_xu_pos.shape)[i_xu_pos] / xpt.T[i_xu_pos]
+    )
     alpha_xu_pos = np.max(alpha_xu_pos, axis=1, initial=np.inf)
     alpha_xu_pos = np.broadcast_to(np.atleast_1d(alpha_xu_pos), xpt.shape[1])
 

--- a/cobyqa/subsolvers/geometry.py
+++ b/cobyqa/subsolvers/geometry.py
@@ -5,6 +5,9 @@ import numpy as np
 from ..utils import get_arrays_tol
 
 
+TINY = np.finfo(float).tiny
+
+
 def cauchy_geometry(const, grad, curv, xl, xu, delta, debug):
     r"""
     Maximize approximately the absolute value of a quadratic function subject
@@ -186,7 +189,7 @@ def spider_geometry(const, grad, curv, xpt, xl, xu, delta, debug):
     for k in range(xpt.shape[1]):
         # Set alpha_tr to the step size for the trust-region constraint.
         s_norm = np.linalg.norm(xpt[:, k])
-        if s_norm > np.finfo(float).tiny * delta:
+        if s_norm > TINY * delta:
             alpha_tr = max(delta / s_norm, 0.0)
         else:
             # The current straight line is basically zero.
@@ -194,10 +197,10 @@ def spider_geometry(const, grad, curv, xpt, xl, xu, delta, debug):
 
         # Set alpha_xl to the step size for the lower-bound constraint and
         # alpha_xu to the step size for the upper-bound constraint.
-        i_xl_pos = (xl > -np.inf) & (xpt[:, k] > -np.finfo(float).tiny * xl)
-        i_xl_neg = (xl > -np.inf) & (xpt[:, k] < np.finfo(float).tiny * xl)
-        i_xu_pos = (xu < np.inf) & (xpt[:, k] > np.finfo(float).tiny * xu)
-        i_xu_neg = (xu < np.inf) & (xpt[:, k] < -np.finfo(float).tiny * xu)
+        i_xl_pos = (xl > -np.inf) & (xpt[:, k] > -TINY * xl)
+        i_xl_neg = (xl > -np.inf) & (xpt[:, k] < TINY * xl)
+        i_xu_pos = (xu < np.inf) & (xpt[:, k] > TINY * xu)
+        i_xu_neg = (xu < np.inf) & (xpt[:, k] < -TINY * xu)
         alpha_xl_pos = np.max(xl[i_xl_pos] / xpt[i_xl_pos, k], initial=-np.inf)
         alpha_xl_neg = np.min(xl[i_xl_neg] / xpt[i_xl_neg, k], initial=np.inf)
         alpha_xu_neg = np.max(xu[i_xu_neg] / xpt[i_xu_neg, k], initial=-np.inf)
@@ -211,18 +214,18 @@ def spider_geometry(const, grad, curv, xpt, xl, xu, delta, debug):
         curv_step = curv(xpt[:, k])
         if (
             grad_step >= 0.0
-            and curv_step < -np.finfo(float).tiny * grad_step
+            and curv_step < -TINY * grad_step
             or grad_step <= 0.0
-            and curv_step > -np.finfo(float).tiny * grad_step
+            and curv_step > -TINY * grad_step
         ):
             alpha_quad_pos = max(-grad_step / curv_step, 0.0)
         else:
             alpha_quad_pos = np.inf
         if (
             grad_step >= 0.0
-            and curv_step > np.finfo(float).tiny * grad_step
+            and curv_step > TINY * grad_step
             or grad_step <= 0.0
-            and curv_step < np.finfo(float).tiny * grad_step
+            and curv_step < TINY * grad_step
         ):
             alpha_quad_neg = min(-grad_step / curv_step, 0.0)
         else:
@@ -297,7 +300,7 @@ def _cauchy_geom(const, grad, curv, xl, xu, delta, debug):
             delta_reduced = np.sqrt(
                 delta**2.0 - cauchy_step[~working] @ cauchy_step[~working]
             )
-            if g_norm > np.finfo(float).tiny * abs(delta_reduced):
+            if g_norm > TINY * abs(delta_reduced):
                 mu = max(delta_reduced / g_norm, 0.0)
             else:
                 break
@@ -318,7 +321,7 @@ def _cauchy_geom(const, grad, curv, xl, xu, delta, debug):
     if grad_step >= 0.0:
         # Set alpha_tr to the step size for the trust-region constraint.
         s_norm = np.linalg.norm(cauchy_step)
-        if s_norm > np.finfo(float).tiny * delta:
+        if s_norm > TINY * delta:
             alpha_tr = max(delta / s_norm, 0.0)
         else:
             # The Cauchy step is basically zero.
@@ -326,14 +329,14 @@ def _cauchy_geom(const, grad, curv, xl, xu, delta, debug):
 
         # Set alpha_quad to the step size for the maximization problem.
         curv_step = curv(cauchy_step)
-        if curv_step < -np.finfo(float).tiny * grad_step:
+        if curv_step < -TINY * grad_step:
             alpha_quad = max(-grad_step / curv_step, 0.0)
         else:
             alpha_quad = np.inf
 
         # Set alpha_bd to the step size for the bound constraints.
-        i_xl = (xl > -np.inf) & (cauchy_step < np.finfo(float).tiny * xl)
-        i_xu = (xu < np.inf) & (cauchy_step > np.finfo(float).tiny * xu)
+        i_xl = (xl > -np.inf) & (cauchy_step < TINY * xl)
+        i_xu = (xu < np.inf) & (cauchy_step > TINY * xu)
         alpha_xl = np.min(xl[i_xl] / cauchy_step[i_xl], initial=np.inf)
         alpha_xu = np.min(xu[i_xu] / cauchy_step[i_xu], initial=np.inf)
         alpha_bd = min(alpha_xl, alpha_xu)

--- a/cobyqa/subsolvers/optim.py
+++ b/cobyqa/subsolvers/optim.py
@@ -6,6 +6,10 @@ from scipy.linalg import qr
 from ..utils import get_arrays_tol
 
 
+TINY = np.finfo(float).tiny
+EPS = np.finfo(float).eps
+
+
 def tangential_byrd_omojokun(grad, hess_prod, xl, xu, delta, debug, **kwargs):
     r"""
     Minimize approximately a quadratic function subject to bound constraints in
@@ -105,7 +109,7 @@ def tangential_byrd_omojokun(grad, hess_prod, xl, xu, delta, debug, **kwargs):
         grad_sd = grad @ sd
         if (
             grad_sd
-            >= -10.0 * np.finfo(float).eps * n * max(1.0, np.linalg.norm(grad))
+            >= -10.0 * EPS * n * max(1.0, np.linalg.norm(grad))
         ):
             break
 
@@ -123,7 +127,7 @@ def tangential_byrd_omojokun(grad, hess_prod, xl, xu, delta, debug, **kwargs):
         # Set alpha_quad to the step size for the minimization problem.
         hess_sd = hess_prod(sd)
         curv_sd = sd @ hess_sd
-        if curv_sd > np.finfo(float).tiny * abs(grad_sd):
+        if curv_sd > TINY * abs(grad_sd):
             alpha_quad = max(-grad_sd / curv_sd, 0.0)
         else:
             alpha_quad = np.inf
@@ -136,9 +140,9 @@ def tangential_byrd_omojokun(grad, hess_prod, xl, xu, delta, debug, **kwargs):
 
         # Set alpha_bd to the step size for the bound constraints.
         i_xl = (
-            (xl > -np.inf) & (sd < -np.finfo(float).tiny * np.abs(xl - step))
+            (xl > -np.inf) & (sd < -TINY * np.abs(xl - step))
         )
-        i_xu = (xu < np.inf) & (sd > np.finfo(float).tiny * np.abs(xu - step))
+        i_xu = (xu < np.inf) & (sd > TINY * np.abs(xu - step))
         all_alpha_xl = np.full_like(step, np.inf)
         all_alpha_xu = np.full_like(step, np.inf)
         all_alpha_xl[i_xl] = np.maximum(
@@ -215,7 +219,7 @@ def tangential_byrd_omojokun(grad, hess_prod, xl, xu, delta, debug, **kwargs):
             if (
                 grad_sd >= -1e-8 * reduct
                 or np.any(
-                    grad_sd >= -np.finfo(float).tiny * np.abs(sd[free_bd])
+                    grad_sd >= -TINY * np.abs(sd[free_bd])
                 )
             ):
                 break
@@ -240,8 +244,8 @@ def tangential_byrd_omojokun(grad, hess_prod, xl, xu, delta, debug, **kwargs):
             )
             dist_xl = np.maximum(step - xl, 0.0)
             dist_xu = np.maximum(xu - step, 0.0)
-            i_xl = temp_xl > np.finfo(float).tiny * dist_xl
-            i_xu = temp_xu > np.finfo(float).tiny * dist_xu
+            i_xl = temp_xl > TINY * dist_xl
+            i_xu = temp_xu > TINY * dist_xu
             all_t_xl = np.ones(n)
             all_t_xu = np.ones(n)
             all_t_xl[i_xl] = np.minimum(
@@ -460,7 +464,7 @@ def constrained_tangential_byrd_omojokun(
         grad_sd = grad @ sd
         if (
             grad_sd
-            >= -10.0 * np.finfo(float).eps * n * max(1.0, np.linalg.norm(grad))
+            >= -10.0 * EPS * n * max(1.0, np.linalg.norm(grad))
         ):
             break
 
@@ -478,7 +482,7 @@ def constrained_tangential_byrd_omojokun(
         # Set alpha_quad to the step size for the minimization problem.
         hess_sd = hess_prod(sd)
         curv_sd = sd @ hess_sd
-        if curv_sd > np.finfo(float).tiny * abs(grad_sd):
+        if curv_sd > TINY * abs(grad_sd):
             alpha_quad = max(-grad_sd / curv_sd, 0.0)
         else:
             alpha_quad = np.inf
@@ -493,12 +497,12 @@ def constrained_tangential_byrd_omojokun(
         i_xl = (
             free_xl
             & (xl > -np.inf)
-            & (sd < -np.finfo(float).tiny * np.abs(xl - step))
+            & (sd < -TINY * np.abs(xl - step))
         )
         i_xu = (
             free_xu
             & (xu < np.inf)
-            & (sd > np.finfo(float).tiny * np.abs(xu - step))
+            & (sd > TINY * np.abs(xu - step))
         )
         all_alpha_xl = np.full_like(step, np.inf)
         all_alpha_xu = np.full_like(step, np.inf)
@@ -516,7 +520,7 @@ def constrained_tangential_byrd_omojokun(
 
         # Set alpha_ub to the step size for the linear constraints.
         aub_sd = aub @ sd
-        i_ub = free_ub & (aub_sd > np.finfo(float).tiny * np.abs(resid))
+        i_ub = free_ub & (aub_sd > TINY * np.abs(resid))
         all_alpha_ub = np.full_like(bub, np.inf)
         all_alpha_ub[i_ub] = resid[i_ub] / aub_sd[i_ub]
         alpha_ub = np.min(all_alpha_ub, initial=np.inf)
@@ -603,7 +607,7 @@ def constrained_tangential_byrd_omojokun(
             )
             if (
                 grad_sd >= -1e-8 * reduct
-                or np.any(grad_sd >= -np.finfo(float).tiny * np.abs(sd))
+                or np.any(grad_sd >= -TINY * np.abs(sd))
             ):
                 break
             sd /= -grad_sd
@@ -636,8 +640,8 @@ def constrained_tangential_byrd_omojokun(
             temp_xu[temp_xu > 0.0] = (
                 np.sqrt(temp_xu[temp_xu > 0.0]) + sd[temp_xu > 0.0]
             )
-            i_xl = temp_xl > np.finfo(float).tiny * dist_xl
-            i_xu = temp_xu > np.finfo(float).tiny * dist_xu
+            i_xl = temp_xl > TINY * dist_xl
+            i_xu = temp_xu > TINY * dist_xu
             all_t_xl = np.ones(n)
             all_t_xu = np.ones(n)
             all_t_xl[i_xl] = np.minimum(
@@ -664,7 +668,7 @@ def constrained_tangential_byrd_omojokun(
             temp_ub[temp_ub > 0.0] = (
                 np.sqrt(temp_ub[temp_ub > 0.0]) + aub_sd[temp_ub > 0.0]
             )
-            i_ub = temp_ub > np.finfo(float).tiny * resid
+            i_ub = temp_ub > TINY * resid
             all_t_ub = np.ones_like(resid)
             all_t_ub[i_ub] = np.minimum(
                 all_t_ub[i_ub],
@@ -889,7 +893,7 @@ def normal_byrd_omojokun(aub, bub, aeq, beq, xl, xu, delta, debug, **kwargs):
         grad_sd = grad @ sd
         if (
             grad_sd
-            >= -10.0 * np.finfo(float).eps * n * max(1.0, np.linalg.norm(grad))
+            >= -10.0 * EPS * n * max(1.0, np.linalg.norm(grad))
         ):
             break
 
@@ -914,7 +918,7 @@ def normal_byrd_omojokun(aub, bub, aeq, beq, xl, xu, delta, debug, **kwargs):
         # Set alpha_quad to the step size for the minimization problem.
         hess_sd = np.r_[aeq.T @ (aeq @ sd[:n]), sd[n:]]
         curv_sd = sd @ hess_sd
-        if curv_sd > np.finfo(float).tiny * abs(grad_sd):
+        if curv_sd > TINY * abs(grad_sd):
             alpha_quad = max(-grad_sd / curv_sd, 0.0)
         else:
             alpha_quad = np.inf
@@ -929,16 +933,16 @@ def normal_byrd_omojokun(aub, bub, aeq, beq, xl, xu, delta, debug, **kwargs):
         i_xl = (
             free_xl
             & (xl > -np.inf)
-            & (sd[:n] < -np.finfo(float).tiny * np.abs(xl - step))
+            & (sd[:n] < -TINY * np.abs(xl - step))
         )
         i_xu = (
             free_xu
             & (xu < np.inf)
-            & (sd[:n] > np.finfo(float).tiny * np.abs(xu - step))
+            & (sd[:n] > TINY * np.abs(xu - step))
         )
         i_slack = (
             free_slack
-            & (sd[n:] < -np.finfo(float).tiny * np.abs(grad[n:]))
+            & (sd[n:] < -TINY * np.abs(grad[n:]))
         )
         all_alpha_xl = np.full_like(step, np.inf)
         all_alpha_xu = np.full_like(step, np.inf)
@@ -962,7 +966,7 @@ def normal_byrd_omojokun(aub, bub, aeq, beq, xl, xu, delta, debug, **kwargs):
 
         # Set alpha_ub to the step size for the linear constraints.
         aub_sd = aub @ sd[:n] - sd[n:]
-        i_ub = free_ub & (aub_sd > np.finfo(float).tiny * np.abs(resid))
+        i_ub = free_ub & (aub_sd > TINY * np.abs(resid))
         all_alpha_ub = np.full_like(bub, np.inf)
         all_alpha_ub[i_ub] = resid[i_ub] / aub_sd[i_ub]
         alpha_ub = np.min(all_alpha_ub, initial=np.inf)
@@ -1041,7 +1045,7 @@ def normal_byrd_omojokun(aub, bub, aeq, beq, xl, xu, delta, debug, **kwargs):
             if (
                 grad_sd >= -1e-8 * reduct
                 or np.any(
-                    grad_sd >= -np.finfo(float).tiny * np.abs(sd[free_bd])
+                    grad_sd >= -TINY * np.abs(sd[free_bd])
                 )
             ):
                 break
@@ -1066,8 +1070,8 @@ def normal_byrd_omojokun(aub, bub, aeq, beq, xl, xu, delta, debug, **kwargs):
             )
             dist_xl = np.maximum(step - xl, 0.0)
             dist_xu = np.maximum(xu - step, 0.0)
-            i_xl = temp_xl > np.finfo(float).tiny * dist_xl
-            i_xu = temp_xu > np.finfo(float).tiny * dist_xu
+            i_xl = temp_xl > TINY * dist_xl
+            i_xu = temp_xu > TINY * dist_xu
             all_t_xl = np.ones(n)
             all_t_xu = np.ones(n)
             all_t_xl[i_xl] = np.minimum(
@@ -1178,7 +1182,7 @@ def qr_tangential_byrd_omojokun(aub, aeq, free_xl, free_xu, free_ub):
     n_act = np.count_nonzero(
         np.abs(np.diag(r))
         >= 10.0
-        * np.finfo(float).eps
+        * EPS
         * n
         * np.linalg.norm(r[: np.min(r.shape), : np.min(r.shape)], axis=0)
     )
@@ -1213,7 +1217,7 @@ def qr_normal_byrd_omojokun(aub, free_xl, free_xu, free_slack, free_ub):
     n_act = np.count_nonzero(
         np.abs(np.diag(r))
         >= 10.0
-        * np.finfo(float).eps
+        * EPS
         * (n + m_linear_ub)
         * np.linalg.norm(r[: np.min(r.shape), : np.min(r.shape)], axis=0)
     )
@@ -1225,9 +1229,9 @@ def _alpha_tr(step, sd, delta):
     sd_sq = sd @ sd
     dist_tr_sq = delta**2.0 - step @ step
     temp = np.sqrt(max(step_sd**2.0 + sd_sq * dist_tr_sq, 0.0))
-    if step_sd <= 0.0 and sd_sq > np.finfo(float).tiny * abs(temp - step_sd):
+    if step_sd <= 0.0 and sd_sq > TINY * abs(temp - step_sd):
         alpha_tr = max((temp - step_sd) / sd_sq, 0.0)
-    elif abs(temp + step_sd) > np.finfo(float).tiny * dist_tr_sq:
+    elif abs(temp + step_sd) > TINY * dist_tr_sq:
         alpha_tr = max(dist_tr_sq / (temp + step_sd), 0.0)
     else:
         raise ZeroDivisionError

--- a/cobyqa/subsolvers/optim.py
+++ b/cobyqa/subsolvers/optim.py
@@ -207,6 +207,8 @@ def tangential_byrd_omojokun(grad, hess_prod, xl, xu, delta, debug, **kwargs):
     # Attempt to improve the solution on the trust-region boundary.
     if kwargs.get("improve_tcg", True) and boundary_reached:
         step_base = np.copy(step)
+        step_comparator = grad_orig @ step_base + 0.5 * step_base @ hess_prod(step_base)
+
         while np.count_nonzero(free_bd) > 0:
             # Check whether a substantial reduction in the objective function
             # is possible, and set the search direction.
@@ -318,7 +320,7 @@ def tangential_byrd_omojokun(grad, hess_prod, xl, xu, delta, debug, **kwargs):
         # function.
         if (
             grad_orig @ step + 0.5 * step @ hess_prod(step)
-            > grad_orig @ step_base + 0.5 * step_base @ hess_prod(step_base)
+            > step_comparator
         ):
             step = step_base
 

--- a/cobyqa/subsolvers/optim.py
+++ b/cobyqa/subsolvers/optim.py
@@ -107,10 +107,7 @@ def tangential_byrd_omojokun(grad, hess_prod, xl, xu, delta, debug, **kwargs):
     while k < np.count_nonzero(free_bd):
         # Stop the computations if sd is not a descent direction.
         grad_sd = grad @ sd
-        if (
-            grad_sd
-            >= -10.0 * EPS * n * max(1.0, np.linalg.norm(grad))
-        ):
+        if grad_sd >= -10.0 * EPS * n * max(1.0, np.linalg.norm(grad)):
             break
 
         # Set alpha_tr to the step size for the trust-region constraint.
@@ -139,9 +136,7 @@ def tangential_byrd_omojokun(grad, hess_prod, xl, xu, delta, debug, **kwargs):
             break
 
         # Set alpha_bd to the step size for the bound constraints.
-        i_xl = (
-            (xl > -np.inf) & (sd < -TINY * np.abs(xl - step))
-        )
+        i_xl = (xl > -np.inf) & (sd < -TINY * np.abs(xl - step))
         i_xu = (xu < np.inf) & (sd > TINY * np.abs(xu - step))
         all_alpha_xl = np.full_like(step, np.inf)
         all_alpha_xu = np.full_like(step, np.inf)
@@ -207,7 +202,9 @@ def tangential_byrd_omojokun(grad, hess_prod, xl, xu, delta, debug, **kwargs):
     # Attempt to improve the solution on the trust-region boundary.
     if kwargs.get("improve_tcg", True) and boundary_reached:
         step_base = np.copy(step)
-        step_comparator = grad_orig @ step_base + 0.5 * step_base @ hess_prod(step_base)
+        step_comparator = grad_orig @ step_base + 0.5 * step_base @ hess_prod(
+            step_base
+        )
 
         while np.count_nonzero(free_bd) > 0:
             # Check whether a substantial reduction in the objective function
@@ -218,11 +215,8 @@ def tangential_byrd_omojokun(grad, hess_prod, xl, xu, delta, debug, **kwargs):
             grad_sd = -np.sqrt(max(step_sq * grad_sq - grad_step**2.0, 0.0))
             sd[free_bd] = grad_step * step[free_bd] - step_sq * grad[free_bd]
             sd[~free_bd] = 0.0
-            if (
-                grad_sd >= -1e-8 * reduct
-                or np.any(
-                    grad_sd >= -TINY * np.abs(sd[free_bd])
-                )
+            if grad_sd >= -1e-8 * reduct or np.any(
+                grad_sd >= -TINY * np.abs(sd[free_bd])
             ):
                 break
             sd[free_bd] /= -grad_sd
@@ -280,9 +274,8 @@ def tangential_byrd_omojokun(grad, hess_prod, xl, xu, delta, debug, **kwargs):
                 grad_step * t_samples
                 - grad_sd
                 - t_samples * curv_step
-                + sin_values * (
-                    t_samples * curv_step_sd - 0.5 * (curv_sd - curv_step)
-                )
+                + sin_values
+                * (t_samples * curv_step_sd - 0.5 * (curv_sd - curv_step))
             )
             if np.all(all_reduct <= 0.0):
                 # No reduction in the objective function is obtained.
@@ -291,9 +284,8 @@ def tangential_byrd_omojokun(grad, hess_prod, xl, xu, delta, debug, **kwargs):
             # Accept the angle that provides the largest reduction in the
             # objective function, and update the iterate.
             i_max = np.argmax(all_reduct)
-            cos_value = (
-                (1.0 - t_samples[i_max] ** 2.0)
-                / (1.0 + t_samples[i_max] ** 2.0)
+            cos_value = (1.0 - t_samples[i_max] ** 2.0) / (
+                1.0 + t_samples[i_max] ** 2.0
             )
             step[free_bd] = (
                 cos_value * step[free_bd] + sin_values[i_max] * sd[free_bd]
@@ -318,10 +310,7 @@ def tangential_byrd_omojokun(grad, hess_prod, xl, xu, delta, debug, **kwargs):
 
         # Ensure that the alternative iteration improves the objective
         # function.
-        if (
-            grad_orig @ step + 0.5 * step @ hess_prod(step)
-            > step_comparator
-        ):
+        if grad_orig @ step + 0.5 * step @ hess_prod(step) > step_comparator:
             step = step_base
 
     if debug:
@@ -420,15 +409,18 @@ def constrained_tangential_byrd_omojokun(
         assert isinstance(xl, np.ndarray) and xl.shape == grad.shape
         assert isinstance(xu, np.ndarray) and xu.shape == grad.shape
         assert (
-            isinstance(aub, np.ndarray) and aub.ndim == 2
+            isinstance(aub, np.ndarray)
+            and aub.ndim == 2
             and aub.shape[1] == grad.size
         )
         assert (
-            isinstance(bub, np.ndarray) and bub.ndim == 1
+            isinstance(bub, np.ndarray)
+            and bub.ndim == 1
             and bub.size == aub.shape[0]
         )
         assert (
-            isinstance(aeq, np.ndarray) and aeq.ndim == 2
+            isinstance(aeq, np.ndarray)
+            and aeq.ndim == 2
             and aeq.shape[1] == grad.size
         )
         assert isinstance(delta, float)
@@ -464,10 +456,7 @@ def constrained_tangential_byrd_omojokun(
     while k < n - n_act:
         # Stop the computations if sd is not a descent direction.
         grad_sd = grad @ sd
-        if (
-            grad_sd
-            >= -10.0 * EPS * n * max(1.0, np.linalg.norm(grad))
-        ):
+        if grad_sd >= -10.0 * EPS * n * max(1.0, np.linalg.norm(grad)):
             break
 
         # Set alpha_tr to the step size for the trust-region constraint.
@@ -496,16 +485,8 @@ def constrained_tangential_byrd_omojokun(
             break
 
         # Set alpha_bd to the step size for the bound constraints.
-        i_xl = (
-            free_xl
-            & (xl > -np.inf)
-            & (sd < -TINY * np.abs(xl - step))
-        )
-        i_xu = (
-            free_xu
-            & (xu < np.inf)
-            & (sd > TINY * np.abs(xu - step))
-        )
+        i_xl = free_xl & (xl > -np.inf) & (sd < -TINY * np.abs(xl - step))
+        i_xu = free_xu & (xu < np.inf) & (sd > TINY * np.abs(xu - step))
         all_alpha_xl = np.full_like(step, np.inf)
         all_alpha_xu = np.full_like(step, np.inf)
         all_alpha_xl[i_xl] = np.maximum(
@@ -603,13 +584,11 @@ def constrained_tangential_byrd_omojokun(
             grad_sq = grad_proj @ grad_proj
             grad_step = grad_proj @ step_proj
             grad_sd = -np.sqrt(max(step_sq * grad_sq - grad_step**2.0, 0.0))
-            sd = (
-                q[:, n_act:]
-                @ (q[:, n_act:].T @ (grad_step * step - step_sq * grad))
+            sd = q[:, n_act:] @ (
+                q[:, n_act:].T @ (grad_step * step - step_sq * grad)
             )
-            if (
-                grad_sd >= -1e-8 * reduct
-                or np.any(grad_sd >= -TINY * np.abs(sd))
+            if grad_sd >= -1e-8 * reduct or np.any(
+                grad_sd >= -TINY * np.abs(sd)
             ):
                 break
             sd /= -grad_sd
@@ -622,19 +601,11 @@ def constrained_tangential_byrd_omojokun(
             temp_xu = np.zeros(n)
             dist_xl = np.maximum(step - xl, 0.0)
             dist_xu = np.maximum(xu - step, 0.0)
-            temp_xl[free_xl] = (
-                sd[free_xl] ** 2.0
-                - dist_xl[free_xl] * (
-                    dist_xl[free_xl]
-                    - 2.0 * step_proj[free_xl]
-                )
+            temp_xl[free_xl] = sd[free_xl] ** 2.0 - dist_xl[free_xl] * (
+                dist_xl[free_xl] - 2.0 * step_proj[free_xl]
             )
-            temp_xu[free_xu] = (
-                sd[free_xu] ** 2.0
-                - dist_xu[free_xu] * (
-                    dist_xu[free_xu]
-                    + 2.0 * step_proj[free_xu]
-                )
+            temp_xu[free_xu] = sd[free_xu] ** 2.0 - dist_xu[free_xu] * (
+                dist_xu[free_xu] + 2.0 * step_proj[free_xu]
             )
             temp_xl[temp_xl > 0.0] = (
                 np.sqrt(temp_xl[temp_xl > 0.0]) - sd[temp_xl > 0.0]
@@ -663,9 +634,8 @@ def constrained_tangential_byrd_omojokun(
             temp_ub = np.zeros_like(resid)
             aub_step = aub @ step_proj
             aub_sd = aub @ sd
-            temp_ub[free_ub] = (
-                aub_sd[free_ub] ** 2.0
-                - resid[free_ub] * (resid[free_ub] + 2.0 * aub_step[free_ub])
+            temp_ub[free_ub] = aub_sd[free_ub] ** 2.0 - resid[free_ub] * (
+                resid[free_ub] + 2.0 * aub_step[free_ub]
             )
             temp_ub[temp_ub > 0.0] = (
                 np.sqrt(temp_ub[temp_ub > 0.0]) + aub_sd[temp_ub > 0.0]
@@ -696,7 +666,8 @@ def constrained_tangential_byrd_omojokun(
             all_reduct = sin_values * (
                 grad_step * t_samples
                 - grad_sd
-                - sin_values * (
+                - sin_values
+                * (
                     0.5 * t_samples**2.0 * curv_step
                     - 2.0 * t_samples * curv_step_sd
                     + 0.5 * curv_sd
@@ -709,9 +680,8 @@ def constrained_tangential_byrd_omojokun(
             # Accept the angle that provides the largest reduction in the
             # objective function, and update the iterate.
             i_max = np.argmax(all_reduct)
-            cos_value = (
-                (1.0 - t_samples[i_max] ** 2.0)
-                / (1.0 + t_samples[i_max] ** 2.0)
+            cos_value = (1.0 - t_samples[i_max] ** 2.0) / (
+                1.0 + t_samples[i_max] ** 2.0
             )
             step = np.clip(
                 step + (cos_value - 1.0) * step_proj + sin_values[i_max] * sd,
@@ -721,7 +691,8 @@ def constrained_tangential_byrd_omojokun(
             grad += (cos_value - 1.0) * hess_step + sin_values[i_max] * hess_sd
             resid = np.maximum(
                 0.0,
-                resid - (cos_value - 1.0) * aub_step
+                resid
+                - (cos_value - 1.0) * aub_step
                 - sin_values[i_max] * aub_sd,
             )
             reduct += all_reduct[i_max]
@@ -753,10 +724,9 @@ def constrained_tangential_byrd_omojokun(
 
         # Ensure that the alternative iteration improves the objective
         # function.
-        if (
-            grad_orig @ step + 0.5 * step @ hess_prod(step)
-            > grad_orig @ step_base + 0.5 * step_base @ hess_prod(step_base)
-        ):
+        if grad_orig @ step + 0.5 * step @ hess_prod(
+            step
+        ) > grad_orig @ step_base + 0.5 * step_base @ hess_prod(step_base):
             step = step_base
 
     if debug:
@@ -839,7 +809,8 @@ def normal_byrd_omojokun(aub, bub, aeq, beq, xl, xu, delta, debug, **kwargs):
     if debug:
         assert isinstance(aub, np.ndarray) and aub.ndim == 2
         assert (
-            isinstance(bub, np.ndarray) and bub.ndim == 1
+            isinstance(bub, np.ndarray)
+            and bub.ndim == 1
             and bub.size == aub.shape[0]
         )
         assert (
@@ -848,7 +819,8 @@ def normal_byrd_omojokun(aub, bub, aeq, beq, xl, xu, delta, debug, **kwargs):
             and aeq.shape[1] == aub.shape[1]
         )
         assert (
-            isinstance(beq, np.ndarray) and beq.ndim == 1
+            isinstance(beq, np.ndarray)
+            and beq.ndim == 1
             and beq.size == aeq.shape[0]
         )
         assert isinstance(xl, np.ndarray) and xl.shape == (aub.shape[1],)
@@ -893,10 +865,7 @@ def normal_byrd_omojokun(aub, bub, aeq, beq, xl, xu, delta, debug, **kwargs):
     while k < n + m_linear_ub - n_act:
         # Stop the computations if sd is not a descent direction.
         grad_sd = grad @ sd
-        if (
-            grad_sd
-            >= -10.0 * EPS * n * max(1.0, np.linalg.norm(grad))
-        ):
+        if grad_sd >= -10.0 * EPS * n * max(1.0, np.linalg.norm(grad)):
             break
 
         # Set alpha_tr to the step size for the trust-region constraint.
@@ -932,20 +901,9 @@ def normal_byrd_omojokun(aub, bub, aeq, beq, xl, xu, delta, debug, **kwargs):
             break
 
         # Set alpha_bd to the step size for the bound constraints.
-        i_xl = (
-            free_xl
-            & (xl > -np.inf)
-            & (sd[:n] < -TINY * np.abs(xl - step))
-        )
-        i_xu = (
-            free_xu
-            & (xu < np.inf)
-            & (sd[:n] > TINY * np.abs(xu - step))
-        )
-        i_slack = (
-            free_slack
-            & (sd[n:] < -TINY * np.abs(grad[n:]))
-        )
+        i_xl = free_xl & (xl > -np.inf) & (sd[:n] < -TINY * np.abs(xl - step))
+        i_xu = free_xu & (xu < np.inf) & (sd[:n] > TINY * np.abs(xu - step))
+        i_slack = free_slack & (sd[n:] < -TINY * np.abs(grad[n:]))
         all_alpha_xl = np.full_like(step, np.inf)
         all_alpha_xu = np.full_like(step, np.inf)
         all_alpha_slack = np.full_like(bub, np.inf)
@@ -1030,9 +988,8 @@ def normal_byrd_omojokun(aub, bub, aeq, beq, xl, xu, delta, debug, **kwargs):
     if kwargs.get("improve_tcg", True) and boundary_reached:
         step_base = np.copy(step)
         free_bd = free_xl & free_xu
-        grad = (
-            aub.T @ np.maximum(aub @ step - bub, 0.0)
-            + aeq.T @ (aeq @ step - beq)
+        grad = aub.T @ np.maximum(aub @ step - bub, 0.0) + aeq.T @ (
+            aeq @ step - beq
         )
         sd = np.zeros(n)
         while np.count_nonzero(free_bd) > 0:
@@ -1044,11 +1001,8 @@ def normal_byrd_omojokun(aub, bub, aeq, beq, xl, xu, delta, debug, **kwargs):
             grad_sd = -np.sqrt(max(step_sq * grad_sq - grad_step**2.0, 0.0))
             sd[free_bd] = grad_step * step[free_bd] - step_sq * grad[free_bd]
             sd[~free_bd] = 0.0
-            if (
-                grad_sd >= -1e-8 * reduct
-                or np.any(
-                    grad_sd >= -TINY * np.abs(sd[free_bd])
-                )
+            if grad_sd >= -1e-8 * reduct or np.any(
+                grad_sd >= -TINY * np.abs(sd[free_bd])
             ):
                 break
             sd[free_bd] /= -grad_sd
@@ -1121,17 +1075,13 @@ def normal_byrd_omojokun(aub, bub, aeq, beq, xl, xu, delta, debug, **kwargs):
             # Accept the angle that provides the largest reduction in the
             # objective function, and update the iterate.
             i_max = np.argmax(all_reduct)
-            cos_value = (
-                (1.0 - t_samples[i_max] ** 2.0)
-                / (1.0 + t_samples[i_max] ** 2.0)
+            cos_value = (1.0 - t_samples[i_max] ** 2.0) / (
+                1.0 + t_samples[i_max] ** 2.0
             )
-            sin_value = (
-                2.0 * t_samples[i_max] / (1.0 + t_samples[i_max] ** 2.0)
-            )
+            sin_value = 2.0 * t_samples[i_max] / (1.0 + t_samples[i_max] ** 2.0)
             step[free_bd] = cos_value * step[free_bd] + sin_value * sd[free_bd]
-            grad = (
-                aub.T @ np.maximum(aub @ step - bub, 0.0)
-                + aeq.T @ (aeq @ step - beq)
+            grad = aub.T @ np.maximum(aub @ step - bub, 0.0) + aeq.T @ (
+                aeq @ step - beq
             )
             reduct += all_reduct[i_max]
 
@@ -1173,12 +1123,14 @@ def qr_tangential_byrd_omojokun(aub, aeq, free_xl, free_xu, free_ub):
     n = free_xl.size
     identity = np.eye(n)
     q, r, _ = qr(
-        np.block([
-            [aeq],
-            [aub[~free_ub, :]],
-            [-identity[~free_xl, :]],
-            [identity[~free_xu, :]],
-        ]).T,
+        np.block(
+            [
+                [aeq],
+                [aub[~free_ub, :]],
+                [-identity[~free_xl, :]],
+                [identity[~free_xu, :]],
+            ]
+        ).T,
         pivoting=True,
     )
     n_act = np.count_nonzero(
@@ -1196,24 +1148,26 @@ def qr_normal_byrd_omojokun(aub, free_xl, free_xu, free_slack, free_ub):
     identity_n = np.eye(n)
     identity_m = np.eye(m_linear_ub)
     q, r, _ = qr(
-        np.block([
+        np.block(
             [
-                aub[~free_ub, :],
-                -identity_m[~free_ub, :],
-            ],
-            [
-                np.zeros((m_linear_ub - np.count_nonzero(free_slack), n)),
-                -identity_m[~free_slack, :],
-            ],
-            [
-                -identity_n[~free_xl, :],
-                np.zeros((n - np.count_nonzero(free_xl), m_linear_ub)),
-            ],
-            [
-                identity_n[~free_xu, :],
-                np.zeros((n - np.count_nonzero(free_xu), m_linear_ub)),
-            ],
-        ]).T,
+                [
+                    aub[~free_ub, :],
+                    -identity_m[~free_ub, :],
+                ],
+                [
+                    np.zeros((m_linear_ub - np.count_nonzero(free_slack), n)),
+                    -identity_m[~free_slack, :],
+                ],
+                [
+                    -identity_n[~free_xl, :],
+                    np.zeros((n - np.count_nonzero(free_xl), m_linear_ub)),
+                ],
+                [
+                    identity_n[~free_xu, :],
+                    np.zeros((n - np.count_nonzero(free_xu), m_linear_ub)),
+                ],
+            ]
+        ).T,
         pivoting=True,
     )
     n_act = np.count_nonzero(

--- a/cobyqa/tests/test_main.py
+++ b/cobyqa/tests/test_main.py
@@ -10,15 +10,15 @@ class TestMinimize:
 
     def setup_method(self):
         self.x0 = [4.0, 1.0]
-        self.options = {'debug': True}
+        self.options = {"debug": True}
 
     @staticmethod
     def fun(x, c=1.0):
-        return x[0]**2 + c * abs(x[1])**3
+        return x[0] ** 2 + c * abs(x[1]) ** 3
 
     @staticmethod
     def con(x):
-        return x[0]**2 + x[1]**2 - 25.0
+        return x[0] ** 2 + x[1] ** 2 - 25.0
 
     def test_simple(self):
         constraints = NonlinearConstraint(self.con, 0.0, 0.0)
@@ -104,8 +104,10 @@ class TestMinimize:
             constraints=constraints,
             options=self.options,
         )
-        constraints_alt = {'fun': self.con, 'type': 'eq'}
-        constraints_alt = standardize_constraints((constraints_alt,), self.x0, "new")
+        constraints_alt = {"fun": self.con, "type": "eq"}
+        constraints_alt = standardize_constraints(
+            (constraints_alt,), self.x0, "new"
+        )
         res_alt = minimize(
             self.fun,
             self.x0,
@@ -184,7 +186,7 @@ class TestMinimize:
 
     def test_target(self):
         options = dict(self.options)
-        options['target'] = 40.0
+        options["target"] = 40.0
         res = minimize(
             self.fun,
             self.x0,
@@ -196,7 +198,7 @@ class TestMinimize:
     def test_max_eval(self):
         constraints = NonlinearConstraint(self.con, 0.0, 0.0)
         options = dict(self.options)
-        options['maxfev'] = 10
+        options["maxfev"] = 10
         res = minimize(
             self.fun,
             self.x0,
@@ -208,7 +210,7 @@ class TestMinimize:
     def test_max_iter(self):
         constraints = NonlinearConstraint(self.con, 0.0, 0.0)
         options = dict(self.options)
-        options['maxiter'] = 5
+        options["maxiter"] = 5
         res = minimize(
             self.fun,
             self.x0,
@@ -236,7 +238,7 @@ class TestMinimize:
                 self.x0,
                 (2.0,),
                 constraints=constraints,
-                options={'history_size': 0},
+                options={"history_size": 0},
             )
         with pytest.raises(ValueError):
             minimize(
@@ -244,7 +246,7 @@ class TestMinimize:
                 self.x0,
                 (2.0,),
                 constraints=constraints,
-                options={'filter_size': 0},
+                options={"filter_size": 0},
             )
         with pytest.raises(ValueError):
             minimize(
@@ -252,7 +254,7 @@ class TestMinimize:
                 self.x0,
                 (2.0,),
                 constraints=constraints,
-                options={'radius_init': 0},
+                options={"radius_init": 0},
             )
         with pytest.raises(ValueError):
             minimize(
@@ -260,7 +262,7 @@ class TestMinimize:
                 self.x0,
                 (2.0,),
                 constraints=constraints,
-                options={'radius_final': -1},
+                options={"radius_final": -1},
             )
         with pytest.raises(ValueError):
             minimize(
@@ -268,7 +270,7 @@ class TestMinimize:
                 self.x0,
                 (2.0,),
                 constraints=constraints,
-                options={'radius_init': 1, 'radius_final': 2},
+                options={"radius_init": 1, "radius_final": 2},
             )
         with pytest.raises(ValueError):
             minimize(
@@ -276,7 +278,7 @@ class TestMinimize:
                 self.x0,
                 (2.0,),
                 constraints=constraints,
-                options={'nb_points': 0},
+                options={"nb_points": 0},
             )
         with pytest.raises(ValueError):
             minimize(
@@ -284,7 +286,7 @@ class TestMinimize:
                 self.x0,
                 (2.0,),
                 constraints=constraints,
-                options={'nb_points': 7},
+                options={"nb_points": 7},
             )
         with pytest.raises(ValueError):
             minimize(
@@ -292,7 +294,7 @@ class TestMinimize:
                 self.x0,
                 (2.0,),
                 constraints=constraints,
-                options={'maxfev': 0},
+                options={"maxfev": 0},
             )
         with pytest.raises(ValueError):
             minimize(
@@ -300,7 +302,7 @@ class TestMinimize:
                 self.x0,
                 (2.0,),
                 constraints=constraints,
-                options={'maxiter': 0},
+                options={"maxiter": 0},
             )
 
     def test_warning(self):
@@ -308,5 +310,5 @@ class TestMinimize:
             minimize(
                 self.fun,
                 self.x0,
-                options={'unknown': 0},
+                options={"unknown": 0},
             )

--- a/cobyqa/tests/test_main.py
+++ b/cobyqa/tests/test_main.py
@@ -1,6 +1,7 @@
 import numpy as np
 import pytest
 from scipy.optimize import Bounds, LinearConstraint, NonlinearConstraint
+from scipy.optimize._minimize import standardize_constraints
 
 from ..main import minimize
 
@@ -104,6 +105,7 @@ class TestMinimize:
             options=self.options,
         )
         constraints_alt = {'fun': self.con, 'type': 'eq'}
+        constraints_alt = standardize_constraints((constraints_alt,), self.x0, "new")
         res_alt = minimize(
             self.fun,
             self.x0,

--- a/cobyqa/tests/test_problem.py
+++ b/cobyqa/tests/test_problem.py
@@ -19,7 +19,7 @@ class BaseTest:
     @staticmethod
     def rosen(x, c=100.0):
         x = np.asarray(x)
-        return np.sum(c * (x[1:] - x[:-1]**2.0)**2.0 + (1.0 - x[:-1])**2.0)
+        return np.sum(c * (x[1:] - x[:-1] ** 2.0) ** 2.0 + (1.0 - x[:-1]) ** 2.0)
 
     class Rosen:
 
@@ -192,11 +192,13 @@ class TestNonlinearConstraint:
 
     def test_args(self):
         nonlinear_constraints = [
-            {'fun': lambda x, c: c * np.cos(x), 'type': 'ineq', 'args': (2.0,)},
-            {'fun': lambda x, c: c * np.sin(x), 'type': 'eq', 'args': (2.0,)},
+            {"fun": lambda x, c: c * np.cos(x), "type": "ineq", "args": (2.0,)},
+            {"fun": lambda x, c: c * np.sin(x), "type": "eq", "args": (2.0,)},
         ]
         x = [0.5, 0.5]
-        nonlinear_constraints = standardize_constraints(nonlinear_constraints, x, "new")
+        nonlinear_constraints = standardize_constraints(
+            nonlinear_constraints, x, "new"
+        )
         constraints = NonlinearConstraints(nonlinear_constraints, False, True)
         c_ub, c_eq = constraints(x)
         np.testing.assert_allclose(

--- a/cobyqa/tests/test_problem.py
+++ b/cobyqa/tests/test_problem.py
@@ -1,6 +1,7 @@
 import numpy as np
 import pytest
 from scipy.optimize import Bounds, LinearConstraint, NonlinearConstraint
+from scipy.optimize._minimize import standardize_constraints
 
 from ..problem import (
     ObjectiveFunction,
@@ -159,8 +160,8 @@ class TestNonlinearConstraint:
         nonlinear_constraints = [
             NonlinearConstraint(np.cos, [-0.5, -0.5], [0.0, 0.0]),
             NonlinearConstraint(np.sin, [1.0, 1.0], [1.0, 1.0]),
-            {'fun': np.tan, 'type': 'ineq', 'args': ()},
-            {'fun': lambda x: np.inner(x, x) - 1.0, 'type': 'eq', 'args': ()},
+            NonlinearConstraint(np.tan, -np.inf, np.inf),
+            NonlinearConstraint(lambda x: np.inner(x, x) - 1.0, 0, 0),
         ]
         constraints = NonlinearConstraints(nonlinear_constraints, False, True)
         assert constraints.n_eval == 0
@@ -168,7 +169,7 @@ class TestNonlinearConstraint:
         c_ub, c_eq = constraints(x)
         np.testing.assert_allclose(
             c_ub,
-            np.block([-0.5 - np.cos(x), np.cos(x), -np.tan(x)]),
+            np.block([-0.5 - np.cos(x), np.cos(x)]),
             atol=1e-15,
         )
         np.testing.assert_allclose(
@@ -177,7 +178,7 @@ class TestNonlinearConstraint:
             atol=1e-15,
         )
         assert constraints.n_eval == 1
-        assert constraints.m_ub == 6
+        assert constraints.m_ub == 4
         assert constraints.m_eq == 3
         np.testing.assert_allclose(
             constraints.maxcv(x, c_ub, c_eq),
@@ -191,11 +192,12 @@ class TestNonlinearConstraint:
 
     def test_args(self):
         nonlinear_constraints = [
-            {'fun': lambda x, c: c * np.cos(x), 'type': 'ineq', 'args': 2.0},
-            {'fun': lambda x, c: c * np.sin(x), 'type': 'eq', 'args': 2.0},
+            {'fun': lambda x, c: c * np.cos(x), 'type': 'ineq', 'args': (2.0,)},
+            {'fun': lambda x, c: c * np.sin(x), 'type': 'eq', 'args': (2.0,)},
         ]
-        constraints = NonlinearConstraints(nonlinear_constraints, False, True)
         x = [0.5, 0.5]
+        nonlinear_constraints = standardize_constraints(nonlinear_constraints, x, "new")
+        constraints = NonlinearConstraints(nonlinear_constraints, False, True)
         c_ub, c_eq = constraints(x)
         np.testing.assert_allclose(
             c_ub,

--- a/cobyqa/utils/math.py
+++ b/cobyqa/utils/math.py
@@ -1,6 +1,9 @@
 import numpy as np
 
 
+EPS = np.finfo(float).eps
+
+
 def get_arrays_tol(*arrays):
     """
     Get a relative tolerance for a set of arrays.
@@ -27,7 +30,7 @@ def get_arrays_tol(*arrays):
         np.max(np.abs(array[np.isfinite(array)]), initial=1.0)
         for array in arrays
     )
-    return 10.0 * np.finfo(float).eps * max(size, 1.0) * weight
+    return 10.0 * EPS * max(size, 1.0) * weight
 
 
 def exact_1d_array(x, message):


### PR DESCRIPTION
It's become clear from CI testing on scipy that the speed of the `cobyqa` method in `optimize.minimize` is definitely on the slow end, and needs to be improved. Please see https://github.com/scipy/scipy/issues/20724.

The inefficiency of the implementation is not because cobyqa takes too many iterations. Rather, there are inefficiencies in the way that the code is architected.

Unfortunately the performance is such that we may have to consider backing out the merge of the solver before we release the next scipy version. Given the amount of effort that's already been put into integrating the solver that's not a path that we would like to go down if at all possible.

In this PR I've attempted to tackle some of the low hanging fruit for trying to speed things up. This PR reduces the execution time by a factor of ~55% on test outlined in the linked issue.

Viz:
- repeated calls to `np.finfo` take a finite amount of time, so eliminate them.
- don't repeatedly calculate `problem.BoundConstraints.is_feasible`,  `problem.BoundConstraints.m` in a property. Create those attributes once on object creation.
- A lot of the infrastructure for calculating constraint slack, constraint violation, processing of constraints, etc, is already contained in `optimize._constraints.NonlinearConstraint`, `optimize._constraints.PreparedConstraint`, etc. Just use that prexisting infrastructure. It's easier for the scipy developers to maintain into the future. Furthermore this infrastructure already takes advantage of caching. Going forward new minimisers added to `scipy.optimize` will be directed to use `NonlinearConstraint`, `Bounds`, `LinearConstraint` instead of the old-school `dict` approach (which is more complicated to use), I therefore removed support for the dict based constraints. This also clears up the internals of the code.
- in `TrustRegion.merit`, only do linear algebra calculation when required.
- When building the A matrix of the interpolation system I've added caching to `build_system`.
- In `subsolvers.geometry.spider_geometry` lift some variables out of the loop by vectorising them.
- finally fix the cobyqa test suite to reflect the changes made. Also check against the `scipy.optimize` test suite.

The release period for scipy is just about to start (in the next 10 days or so). Given that there is very limited time is it possible to merge this PR within the next few days? The alternative is for us to back out the cobyqa merge into scipy, with a view to improving performance for the 1.15 release in about 6 months.

I appreciate any help you're able to give.

@zaikunzhang @ragonneau 