### PR TITLE
Use best point for callbacks

### DIFF
--- a/cobyqa/problem.py
+++ b/cobyqa/problem.py
@@ -881,7 +881,8 @@ class Problem:
             sig = signature(self._callback)
             try:
                 if set(sig.parameters) == {"intermediate_result"}:
-                    intermediate_result = OptimizeResult(x=x_full, fun=fun_val)
+                    x_best, fun_val_best, _ = self.best_eval(0.0)
+                    intermediate_result = OptimizeResult(x=x_best, fun=fun_val_best)
                     self._callback(intermediate_result=intermediate_result)
                 else:
                     self._callback(x_full)


### PR DESCRIPTION
Hi guys,

as @andyfaff mentioned [here](https://github.com/scipy/scipy/issues/21061), the default behavior for `scipy` is to use the current best point for callbacks, and not the latest evaluated point. While I understand that it might also be valuable being able to do additional processing on the latest point, I think it's important to be consistent with what's expected. 

Hoping that this doesn't break any of your workflows, this PR fixes this behavior.

I was not sure whether I understood the `Problem.best_eval` method correctly and whether the penalty of `0.0` is the correct choice here.

---
Fixes #157